### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,9 @@ name: Go
 
 on: push
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/julieta-311/pgx-sandbox/security/code-scanning/1](https://github.com/julieta-311/pgx-sandbox/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/go.yml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
For this workflow, the minimal required permission is:

- `contents: read` (needed by `actions/checkout`)

Best single fix without changing functionality:
- Insert:
  ```yaml
  permissions:
    contents: read
  ```
  directly after the `on:` section and before `jobs:`.

No imports, methods, or additional definitions are needed (YAML workflow only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
